### PR TITLE
Fix build errors VS Community 2019 v.16+

### DIFF
--- a/src/RoslynPad.Editor.Windows/RoslynPad.Editor.Windows.csproj
+++ b/src/RoslynPad.Editor.Windows/RoslynPad.Editor.Windows.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
-    <LanguageTargets>$(MSBuildExtensionsPath)\$(VisualStudioVersion)\Bin\Microsoft.CSharp.targets</LanguageTargets>
+    <LanguageTargets>$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Bin\Microsoft.CSharp.targets</LanguageTargets>
     <OutputType>Library</OutputType>
     <TargetFramework>net46</TargetFramework>
     <PackageTargetFallback>$(PackageTargetFallback);portable-net45+win8+wp8+wpa81;</PackageTargetFallback>

--- a/src/RoslynPad.Roslyn.Windows/RoslynPad.Roslyn.Windows.csproj
+++ b/src/RoslynPad.Roslyn.Windows/RoslynPad.Roslyn.Windows.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
-    <LanguageTargets>$(MSBuildExtensionsPath)\$(VisualStudioVersion)\Bin\Microsoft.CSharp.targets</LanguageTargets>
+    <LanguageTargets>$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Bin\Microsoft.CSharp.targets</LanguageTargets>
     <OutputType>Library</OutputType>
     <TargetFramework>net46</TargetFramework>
     <PackageTargetFallback>$(PackageTargetFallback);portable-net45+win8+wp8+wpa81;</PackageTargetFallback>


### PR DESCRIPTION
There are two projects that uses $(VisualStudioVersion) to locate Microsoft.CSharp.targets file.
It works well for VS2017 and earlier versions, but not recommended in VS2019 since the location of msbuild has changed in VS2019.

The Microsoft.CSharp.targets file which you need for build process actually exists in path ...\2019\Community\MSBuild\Current\Bin\Microsoft.CSharp.targets instead of ...\2019\Community\MSBuild\16.0\Bin\Microsoft.CSharp.targets.

Fixed using $(MSBuildToolsVersion) instead of $(VisualStudioVersion) to locate the .targets file.